### PR TITLE
Remove unnecessary PATH setup

### DIFF
--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -2,11 +2,6 @@
 
 cd "$(dirname "$0")"
 
-if ! which brew >/dev/null; then
-    BREW_PREFIX="/home/linuxbrew/.linuxbrew"
-    PATH="foo:${BREW_PREFIX}/sbin:${BREW_PREFIX}/bin:${PATH}"
-fi
-
 brew bundle
 
 pipx install poetry


### PR DESCRIPTION
This was fixed upstream by the [devcontainer][devcontainer] project, which switched away from multi-stage builds, thereby preserving important environment variables (like the modification of `PATH`).

[devcontainer]: https://github.com/bottle-garden/devcontainer