### PR TITLE
Add the `OBELIST_NO_ERROR` environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ LINT_OUT := lint.tmp
 define sh
 @ printf "\e$(DIM)$$ %s\e$(RESET)\n" \
 	"$$(echo $1 | sed -E 's,make -[^ ]+ ,make ,')" && \
-	SILENT=true $1;
+	OBELIST_NO_ERROR="true" $1;
 endef
 
 .PHONY: help # Print this help message and exit
@@ -55,79 +55,79 @@ update: install-clean update-run install
 
 .PHONY: wtf
 wtf:
-	@ test/linters/wtf.sh || true
+	@ test/linters/wtf.sh
 
 .PHONY: lintspaces
 lintspaces:
-	@ test/linters/lintspaces.sh || true
+	@ test/linters/lintspaces.sh
 
 .PHONY: ec
 ec:
-	@ test/linters/ec.sh || true
+	@ test/linters/ec.sh
 
 .PHONY: misspell
 misspell:
-	@ test/linters/misspell.sh || true
+	@ test/linters/misspell.sh
 
 .PHONY: cspell
 cspell:
-	@ test/linters/cspell.sh || true
+	@ test/linters/cspell.sh
 
 .PHONY: woke
 woke:
-	@ test/linters/woke.sh || true
+	@ test/linters/woke.sh
 
 .PHONY: lychee
 lychee:
-	@ test/linters/lychee.sh || true
+	@ test/linters/lychee.sh
 
 .PHONY: markdown-link-check
 markdown-link-check:
-	@ test/linters/markdown-link-check.sh || true
+	@ test/linters/markdown-link-check.sh
 
 .PHONY: markdownlint
 markdownlint:
-	@ test/linters/markdownlint.sh || true
+	@ test/linters/markdownlint.sh
 
 .PHONY: prettier
 prettier:
-	@ test/linters/prettier.sh || true
+	@ test/linters/prettier.sh
 
 .PHONY: jscpd
 jscpd: $(VENV)
-	@ test/linters/jscpd.sh || true
+	@ test/linters/jscpd.sh
 
 .PHONY: shellcheck
 shellcheck:
-	@ test/linters/shellcheck.sh || true
+	@ test/linters/shellcheck.sh
 
 .PHONY: shfmt
 shfmt:
-	@ test/linters/shfmt.sh || true
+	@ test/linters/shfmt.sh
 
 .PHONY: black
 black: $(VENV)
-	@ test/linters/black.sh || true
+	@ test/linters/black.sh
 
 .PHONY: reorder-python-imports
 reorder-python-imports: $(VENV)
-	@ test/linters/reorder-python-imports.sh || true
+	@ test/linters/reorder-python-imports.sh
 
 .PHONY: prospector
 prospector: $(VENV)
-	@ test/linters/prospector.sh || true
+	@ test/linters/prospector.sh
 
 .PHONY: flake8
 flake8: $(VENV)
-	@ test/linters/flake8.sh || true
+	@ test/linters/flake8.sh
 
 .PHONY: pytest
 pytest: $(VENV)
-	@ test/linters/pytest.sh || true
+	@ test/linters/pytest.sh
 
 .PHONY: codecov
 codecov: $(VENV)
-	@ test/linters/codecov.sh || true
+	@ test/linters/codecov.sh
 
 .PHONY: lint-clean
 lint-clean:

--- a/src/obelist/cli/cmds/format.py
+++ b/src/obelist/cli/cmds/format.py
@@ -1,6 +1,7 @@
 import sys
 
 import click
+
 from obelist import cli
 
 

--- a/src/obelist/cli/cmds/parse.py
+++ b/src/obelist/cli/cmds/parse.py
@@ -10,12 +10,14 @@ from obelist import cli
 @click.argument("input", required=False, default="-", type=click.File("rb"))
 @click.help_option("-h", "--help", help=cli.HELP_STR)
 # TODO: Implement some sort of config guesssing
+# TODO: Allow this to be configured in a global config file
 @click.option(
     "-q",
     "--quiet",
     is_flag=True,
     help="Suppress all non-essential output",
 )
+# TODO: Allow this to be configured in a global config file
 @click.option(
     "-d",
     "--debug",
@@ -34,6 +36,7 @@ from obelist import cli
     required=True,
     help="Specify the parser to use",
 )
+# TODO: Allow this to be configured in a global config file
 # TODO: https://click.palletsprojects.com/en/8.0.x/options/#choice-options
 @click.option(
     "-e",
@@ -55,6 +58,7 @@ from obelist import cli
     required=True,
     help="Specify the input format",
 )
+# TODO: Allow this to be configured in a global config file
 # TODO: https://click.palletsprojects.com/en/8.0.x/options/#choice-options
 @click.option(
     "-s",
@@ -76,6 +80,7 @@ from obelist import cli
         them (can be used in combination with `obelist print` command)
     """,
 )
+# TODO: Allow this to be configured in a global config file
 @click.option(
     "-c",
     "--console",
@@ -86,6 +91,7 @@ from obelist import cli
         `PRINT_CONSOLE` environment variable value)
     """,
 )
+# TODO: Allow this to be configured in a global config file
 @click.option(
     "-b",
     "--before-context",
@@ -97,6 +103,7 @@ from obelist import cli
         Print the specified number of lines before each annotated section
     """,
 )
+# TODO: Allow this to be configured in a global config file
 @click.option(
     "-a",
     "--after-context",
@@ -129,6 +136,13 @@ def parse(
     file. You can specify `-` to read from standard input (STDIN). However,
     when no `INPUT` value is provided, the program will attempt to read from
     STDIN by default.
+
+    If you set the `OBELIST_NO_ERROR` environment variable to `true`, the
+    command will ignore the `--error-on` option and never exit with an error.
+    You can use this feature in conjunction with the `--write` option to log
+    annotations without stopping the build because of a single command error.
+    Afterward, you can process the annotation log in bulk with the `format`
+    command and the `--error-on` option as desired.
 
     When the program exits because of a parsed error message, the returned
     error code corresponds to the highest error message encountered:

--- a/src/obelist/core/app.py
+++ b/src/obelist/core/app.py
@@ -121,10 +121,15 @@ class Application:
         self._parser.read_commands(read_file)
 
     def print(self, sort_by, before_context, after_context):
-        return self._parser.print(
+        status_code = self._parser.print(
             self._error_on,
             self._write_file,
             sort_by,
             before_context,
             after_context,
         )
+        # TODO: Could probably loosen this up so any statement which could
+        # evaluate to true will work (perhaps Click can help with this)
+        if os.environ.get("OBELIST_NO_ERROR") == "true":
+            status_code = 0
+        return status_code

--- a/test/lib/setup/linter.sh
+++ b/test/lib/setup/linter.sh
@@ -3,7 +3,7 @@
 lint_out="${LINT_OUT:=}"
 export lint_out
 
-silent="${SILENT:=}"
+no_error="${OBELIST_NO_ERROR:=}"
 export silent
 
 if test -z "${lint_out}"; then
@@ -11,14 +11,6 @@ if test -z "${lint_out}"; then
     exit 1
 fi
 
-if test "${silent}" != "true"; then
+if test "${no_error}" != "true"; then
     make --no-print-directory lint-clean
 fi
-
-on_exit() {
-    if test "${silent}" != "true"; then
-        make --no-print-directory lint-process
-    fi
-}
-
-trap on_exit EXIT


### PR DESCRIPTION
This feature has allowed me to refactor the build system so that bare targets will produce an error by default.

Only when you run the `lint` target that individual lint checks are prevented from erroring out. The final call to `obelist format` is configured to process the aggregate annotation log and error out on any `notice` annotations.